### PR TITLE
Add a minimal implementation of the spec

### DIFF
--- a/apis/servicebinding/v1alpha2/servicebinding_types.go
+++ b/apis/servicebinding/v1alpha2/servicebinding_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha2
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -98,8 +97,15 @@ type ServiceBindingStatus struct {
 // For long-running resources.
 const ConditionReady ConditionType = "Ready"
 
+const (
+	ConditionTrue    ConditionStatus = "True"
+	ConditionFalse   ConditionStatus = "False"
+	ConditionUnknown ConditionStatus = "Unknown"
+)
+
 type Conditions []Condition
 
+type ConditionStatus string
 type ConditionType string
 
 type Condition struct {
@@ -109,7 +115,7 @@ type Condition struct {
 
 	// Status of the condition, one of True, False, Unknown.
 	// +required
-	Status corev1.ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
+	Status ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
 
 	// LastTransitionTime is the last time the condition transitioned from one status to another.
 	// We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
@@ -128,6 +134,7 @@ type Condition struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // ServiceBinding is the Schema for the servicebindings API
 type ServiceBinding struct {

--- a/config/crd/bases/service.binding_servicebindings.yaml
+++ b/config/crd/bases/service.binding_servicebindings.yaml
@@ -15,6 +15,8 @@ spec:
     plural: servicebindings
     singular: servicebinding
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: ServiceBinding is the Schema for the servicebindings API

--- a/controllers/servicebinding/servicebinding_controller.go
+++ b/controllers/servicebinding/servicebinding_controller.go
@@ -18,14 +18,39 @@ package servicebinding
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/imdario/mergo"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	sbv1alpha2 "github.com/kubepreset/kubepreset/apis/servicebinding/v1alpha2"
 )
+
+// ServiceBindingRoot points to the environment variable in the container
+// which is used as the volume mount path.  In the abscence of this
+// environment variable, `/bindings` is used as the volume mount path.
+// Refer: https://github.com/k8s-service-bindings/spec#reconciler-implementation
+const ServiceBindingRoot = "SERVICE_BINDING_ROOT"
+
+// Status of a ProvisionedService
+// The name will be a reference to a secret
+type Status struct {
+	Binding corev1.LocalObjectReference `json:"binding"`
+}
+
+// ProvisionedService represents the duck-type which could any backing service
+type ProvisionedService struct {
+	Status Status `json:"status"`
+}
 
 // Reconciler reconciles a ServiceBinding object
 type Reconciler struct {
@@ -34,16 +59,237 @@ type Reconciler struct {
 	Scheme *runtime.Scheme
 }
 
+var deploymentGK = schema.GroupKind{Group: "apps", Kind: "Deployment"}
+
 // +kubebuilder:rbac:groups=service.binding,resources=servicebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=service.binding,resources=servicebindings/status,verbs=get;update;patch
 
 // Reconcile based on changes in the ServiceBinding CR or Provisioned Service Secret
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	_ = context.Background()
-	_ = r.Log.WithValues("servicebinding", req.NamespacedName)
+	ctx := context.Background()
+	log := r.Log.WithValues("servicebinding", req.NamespacedName)
 
-	// your logic here
+	log.V(2).Info("starting reconciliation")
 
+	var sb sbv1alpha2.ServiceBinding
+
+	log.V(1).Info("retrieving ServiceBinding object")
+	if err := r.Get(ctx, req.NamespacedName, &sb); err != nil {
+		log.Error(err, "unable to fetch ServiceBinding")
+		// we'll ignore not-found errors, since they can't be fixed by an immediate
+		// requeue (we'll need to wait for a new notification), and we can get them
+		// on deleted requests.
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	log.V(2).Info("ServiceBinding object retrieved", "name", sb.Name, "annotations", sb.Annotations, "labels", sb.Labels)
+	/*
+		if sb.Status.ObservedGeneration == sb.Generation {
+			return ctrl.Result{}, nil
+		}
+	*/
+
+	backingServiceCRLookupKey := client.ObjectKey{Name: sb.Spec.Service.Name, Namespace: req.NamespacedName.Namespace}
+
+	backingServiceCR := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       sb.Spec.Service.Kind,
+			"apiVersion": sb.Spec.Service.APIVersion,
+			"metadata": map[string]interface{}{
+				"name": sb.Spec.Service.Name,
+			},
+		},
+	}
+
+	log.V(1).Info("retrieving the backing service object")
+	if err := r.Get(ctx, backingServiceCRLookupKey, backingServiceCR); err != nil {
+		log.Error(err, "unable to fetch backing service")
+		return ctrl.Result{}, err
+	}
+	log.V(2).Info("backing service object retrieved", "status", backingServiceCR.Object["status"])
+
+	ps := &ProvisionedService{}
+
+	log.V(2).Info("mapping backing service with the provisioned service")
+	if err := mergo.Map(ps, backingServiceCR.Object, mergo.WithOverride); err != nil {
+		return ctrl.Result{}, err
+	}
+	log.V(2).Info("completed mapping backing service with the provisioned service", "provisioned-service", ps)
+
+	secretLookupKey := client.ObjectKey{Name: ps.Status.Binding.Name, Namespace: req.NamespacedName.Namespace}
+	secret := &corev1.Secret{}
+
+	log.V(1).Info("retrieving the secret object")
+	if err := r.Get(ctx, secretLookupKey, secret); err != nil {
+		log.Error(err, "unable to fetch backing service")
+		return ctrl.Result{}, err
+	}
+	log.V(2).Info("the secret object retrieved", "secret-data", secret.Data)
+
+	applicationLookupKey := client.ObjectKey{Name: sb.Spec.Application.Name, Namespace: req.NamespacedName.Namespace}
+
+	application := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       sb.Spec.Application.Kind,
+			"apiVersion": sb.Spec.Application.APIVersion,
+			"metadata": map[string]interface{}{
+				"name": sb.Spec.Application.Name,
+			},
+		},
+	}
+
+	log.V(1).Info("retrieving the application object")
+	if err := r.Get(ctx, applicationLookupKey, application); err != nil {
+		log.Error(err, "unable to fetch application")
+		return ctrl.Result{}, err
+	}
+	log.V(2).Info("application object retrieved", "metadata", application.Object["metadata"])
+
+	volumeProjection := &corev1.Volume{
+		Name: sb.Name, // FIXME: What should be the name?
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: ps.Status.Binding.Name,
+			},
+		},
+	}
+
+	log.V(2).Info("converting the volumeProjection to an unstructured object")
+	unstructuredVolume, err := runtime.DefaultUnstructuredConverter.ToUnstructured(volumeProjection)
+	if err != nil {
+		log.Error(err, "unable to convert volumeProjection to an unstructured object")
+		return ctrl.Result{}, err
+	}
+
+	log.V(2).Info("retrieving the existing volumes as an unstructured object")
+	volumes, found, err := unstructured.NestedSlice(application.Object, "spec", "template", "spec", "volumes")
+	if !found {
+		log.V(2).Info("volumes not found in the application object")
+	}
+	if err != nil {
+		log.Error(err, "locating volumes in the application object")
+		return ctrl.Result{}, err
+	}
+	log.V(2).Info("Volumes values", "volumes", volumes)
+
+	volumeFound := false
+
+	for i, volume := range volumes {
+		log.V(2).Info("Volume", "volume", volume)
+		if sb.Name == volume.(map[string]interface{})["name"] {
+			volumes[i] = unstructuredVolume
+			volumeFound = true
+		}
+	}
+
+	if !volumeFound {
+		volumes = append(volumes, unstructuredVolume)
+	}
+	log.V(2).Info("setting the updated volumes into the application using the unstructured object")
+	if err := unstructured.SetNestedSlice(application.Object, volumes, "spec", "template", "spec", "volumes"); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	log.V(2).Info("retrieving the containers as an unstructured object")
+	containers, found, err := unstructured.NestedSlice(application.Object, "spec", "template", "spec", "containers")
+	if !found {
+		e := &field.Error{Type: field.ErrorTypeRequired, Field: "spec.template.spec.containers", Detail: "empty containers"}
+		log.Error(e, "containers not found in the application object")
+		return ctrl.Result{}, apierrors.NewInvalid(deploymentGK, sb.Spec.Application.Name, field.ErrorList{e})
+	}
+	if err != nil {
+		log.Error(err, "locating containers in the application object")
+		return ctrl.Result{}, err
+	}
+
+	for i := range containers {
+		container := &containers[i]
+		// TODO Set log level to 2
+		log.V(1).Info("updating container", "container", container)
+		c := &corev1.Container{}
+		u := (*container).(map[string]interface{})
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u, c); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		mountPath := ""
+		for _, e := range c.Env {
+			if e.Name == ServiceBindingRoot {
+				mountPath = e.Value
+				break
+			}
+		}
+
+		if mountPath == "" {
+			mountPath = "/bindings"
+			c.Env = append(c.Env, corev1.EnvVar{
+				Name:  ServiceBindingRoot,
+				Value: mountPath,
+			})
+		}
+
+		volumeMount := corev1.VolumeMount{
+			Name:      sb.Name,
+			MountPath: mountPath,
+			ReadOnly:  true,
+		}
+
+		volumeMountFound := false
+		for j, vm := range c.VolumeMounts {
+			if vm.Name == sb.Name {
+				c.VolumeMounts[j] = volumeMount
+				volumeMountFound = true
+				break
+			}
+		}
+
+		if !volumeMountFound {
+			c.VolumeMounts = append(c.VolumeMounts, volumeMount)
+		}
+
+		nu, err := runtime.DefaultUnstructuredConverter.ToUnstructured(c)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		containers[i] = nu
+	}
+
+	// TODO Set log level to 2
+	log.V(1).Info("setting the updated containers into the application using the unstructured object")
+	if err := unstructured.SetNestedSlice(application.Object, containers, "spec", "template", "spec", "containers"); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	log.V(1).Info("updating the application with updated volumes and volumeMounts")
+	if err := r.Update(ctx, application); err != nil {
+		log.Error(err, "unable to update the application")
+		return ctrl.Result{}, err
+	}
+
+	sb.Status.ObservedGeneration = sb.Generation
+
+	conditionFound := false
+	for k, cond := range sb.Status.Conditions {
+		if cond.Type == sbv1alpha2.ConditionReady {
+			sb.Status.Conditions[k] = sbv1alpha2.Condition{Status: "True"}
+			conditionFound = true
+		}
+	}
+
+	if !conditionFound {
+		c := sbv1alpha2.Condition{
+			LastTransitionTime: metav1.NewTime(time.Now()),
+			Type:               sbv1alpha2.ConditionReady,
+			Status:             "True",
+		}
+		sb.Status.Conditions = append(sb.Status.Conditions, c)
+	}
+
+	log.V(1).Info("updating the service binding status")
+	if err := r.Status().Update(ctx, &sb); err != nil {
+		log.Error(err, "unable to update the service binding")
+		return ctrl.Result{}, err
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/servicebinding/servicebinding_controller_test.go
+++ b/controllers/servicebinding/servicebinding_controller_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2020 The KubePreset Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicebinding_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	sbv1alpha2 "github.com/kubepreset/kubepreset/apis/servicebinding/v1alpha2"
+)
+
+var _ = Describe("ServiceBinding Controller:", func() {
+
+	const (
+		timeout       = time.Second * 20
+		interval      = time.Millisecond * 250
+		testNamespace = "default"
+	)
+
+	Context("When creating ServiceBinding with ProvisionedService", func() {
+
+		It("should update the ServiceBinding status conditions for type `Ready` with value `True`", func() {
+			ctx := context.Background()
+			By("Creating BackingService CRD")
+			backingServiceCRD := &apixv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backingservices.app.example.org",
+					Namespace: testNamespace,
+				},
+				Spec: apixv1.CustomResourceDefinitionSpec{
+					Group: "app.example.org",
+					Versions: []apixv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apixv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apixv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apixv1.JSONSchemaProps{
+									"status": {
+										Type: "object",
+										Properties: map[string]apixv1.JSONSchemaProps{
+											"binding": {
+												Type: "object",
+												Properties: map[string]apixv1.JSONSchemaProps{
+													"name": {
+														Type: "string",
+													},
+												},
+												Required: []string{"name"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					},
+					Names: apixv1.CustomResourceDefinitionNames{
+						Plural: "backingservices",
+						Kind:   "BackingService",
+					},
+					Scope: apixv1.ClusterScoped,
+				}}
+			Expect(k8sClient.Create(ctx, backingServiceCRD)).Should(Succeed())
+
+			backingServiceCRDLookupKey := types.NamespacedName{Name: "backingservices.app.example.org", Namespace: testNamespace}
+			createdBackingServiceCRD := &apixv1.CustomResourceDefinition{}
+
+			By("Verifying BackingService CRD")
+			// Retry getting newly created BackingService CRD
+			// Important: This is required as it is going to be used immediately
+			Eventually(func() bool {
+				// FIXME: `k8sClient` seems to be not working
+				err := k8sClient2.Get(ctx, backingServiceCRDLookupKey, createdBackingServiceCRD)
+				if err != nil {
+					return false
+				}
+				for _, condition := range createdBackingServiceCRD.Status.Conditions {
+					if condition.Type == apixv1.Established &&
+						condition.Status == apixv1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Creating Secret")
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: testNamespace,
+				},
+				StringData: map[string]string{
+					"type":     "secret",
+					"provider": "backingservice",
+					"username": "guest",
+					"password": "password",
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+
+			By("Creating BackingService CR")
+			backingServiceCR := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "BackingService",
+					"apiVersion": "app.example.org/v1alpha1",
+					"metadata": map[string]interface{}{
+						"name": "back1",
+					},
+					"status": map[string]interface{}{
+						"binding": map[string]interface{}{
+							"name": "secret1",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, backingServiceCR)).Should(Succeed())
+
+			matchLabels := map[string]string{
+				"environment": "test",
+			}
+
+			app := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "app",
+					Labels:    matchLabels,
+					Namespace: testNamespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: matchLabels,
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "app",
+							Namespace: testNamespace,
+							Labels:    matchLabels,
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:    "busybox",
+								Image:   "busybox:latest",
+								Command: []string{"sleep", "3600"},
+							}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).Should(Succeed())
+
+			sb := &sbv1alpha2.ServiceBinding{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "service.binding/v1alpha2",
+					Kind:       "ServiceBinding",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sb",
+					Namespace: testNamespace,
+				},
+				Spec: sbv1alpha2.ServiceBindingSpec{
+					Application: &sbv1alpha2.Application{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       "app",
+					},
+					Service: &sbv1alpha2.Service{
+						APIVersion: "app.example.org/v1alpha1",
+						Kind:       "BackingService",
+						Name:       "back1",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sb)).Should(Succeed())
+
+			serviceBindingLookupKey := types.NamespacedName{Name: "sb", Namespace: testNamespace}
+			createdServiceBinding := &sbv1alpha2.ServiceBinding{}
+
+			// Retry getting newly created ServiceBinding; the status may not be immediately reflected.
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceBindingLookupKey, createdServiceBinding)
+				if err != nil {
+					return false
+				}
+				for _, condition := range createdServiceBinding.Status.Conditions {
+					if condition.Type == sbv1alpha2.ConditionReady &&
+						condition.Status == sbv1alpha2.ConditionTrue {
+						return true
+					}
+				}
+				return false
+
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(len(createdServiceBinding.Status.Conditions)).To(Equal(1))
+			// FIXME: Fragile?
+			Expect(createdServiceBinding.Status.ObservedGeneration).To(Equal(int64(1)))
+
+			applicationLookupKey := types.NamespacedName{Name: sb.Spec.Application.Name, Namespace: testNamespace}
+
+			Expect(k8sClient.Get(ctx, applicationLookupKey, app)).Should(Succeed())
+			Expect(len(app.Spec.Template.Spec.Volumes)).To(Equal(1))
+			Expect(app.Spec.Template.Spec.Volumes[0].Name).To(Equal("sb"))
+			Expect(app.Spec.Template.Spec.Containers[0].Env[0].Value).To(Equal("/bindings"))
+
+		})
+	})
+})

--- a/controllers/servicebinding/suite_test.go
+++ b/controllers/servicebinding/suite_test.go
@@ -92,10 +92,10 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	err = sbv1alpha2.AddToScheme(scheme.Scheme)
+	err = apixv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = apixv1.AddToScheme(scheme.Scheme)
+	err = sbv1alpha2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.13
 
 require (
 	github.com/go-logr/logr v0.1.0
+	github.com/google/uuid v1.1.2
+	github.com/imdario/mergo v0.3.11
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	go.uber.org/zap v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
@@ -166,6 +168,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
+github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -410,6 +414,8 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Implement a sub-set of the core spec without any extensions. The goal is to create a minimal working implementation.

Features not implemented which is part of the core spec:

- Label selector for application
- Mappings
- Environment variable

The above features will be implemented in subsequent pull requests.
