### PR TITLE
Add support for spec level values to override

### DIFF
--- a/apis/servicebinding/v1alpha2/servicebinding_types.go
+++ b/apis/servicebinding/v1alpha2/servicebinding_types.go
@@ -17,16 +17,21 @@ limitations under the License.
 package v1alpha2
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+// Important: Run "make" to regenerate code after modifying this file
 
 // ServiceBindingSpec defines the desired state of ServiceBinding
 type ServiceBindingSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+
+	// Name is the name of the service as projected into the application container.  Defaults to .metadata.name.
+	Name string `json:"name,omitempty"`
+	// Type is the type of the service as projected into the application container
+	Type string `json:"type,omitempty"`
+	// Provider is the provider of the service as projected into the application container
+	Provider string `json:"provider,omitempty"`
 
 	// Application resource to inject the binding info.
 	// It could be any process running within a container.
@@ -91,6 +96,9 @@ type ServiceBindingStatus struct {
 	// Conditions the latest available observations of a resource's current state.
 	// +optional
 	Conditions Conditions `json:"conditions,omitempty"`
+
+	// Binding exposes the projected secret for this ServiceBinding
+	Binding *corev1.LocalObjectReference `json:"binding,omitempty"`
 }
 
 // ConditionReady specifies that the resource is ready.

--- a/apis/servicebinding/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/servicebinding/v1alpha2/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha2
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -190,6 +191,11 @@ func (in *ServiceBindingStatus) DeepCopyInto(out *ServiceBindingStatus) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Binding != nil {
+		in, out := &in.Binding, &out.Binding
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
 	}
 }
 

--- a/config/crd/bases/service.binding_servicebindings.yaml
+++ b/config/crd/bases/service.binding_servicebindings.yaml
@@ -100,6 +100,14 @@ spec:
                       type: object
                   type: object
               type: object
+            name:
+              description: Name is the name of the service as projected into the application
+                container.  Defaults to .metadata.name.
+              type: string
+            provider:
+              description: Provider is the provider of the service as projected into
+                the application container
+              type: string
             service:
               description: 'Service referencing the binding secret From the spec:
                 A Service Binding resource **MUST** define a `.spec.service` which
@@ -116,6 +124,10 @@ spec:
                   description: Name of the referent. Mutually exclusive with Selector.
                   type: string
               type: object
+            type:
+              description: Type is the type of the service as projected into the application
+                container
+              type: string
           required:
           - application
           - service
@@ -123,6 +135,14 @@ spec:
         status:
           description: ServiceBindingStatus defines the observed state of ServiceBinding
           properties:
+            binding:
+              description: Binding exposes the projected secret for this ServiceBinding
+              properties:
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                  type: string
+              type: object
             conditions:
               description: Conditions the latest available observations of a resource's
                 current state.

--- a/controllers/servicebinding/suite_test.go
+++ b/controllers/servicebinding/suite_test.go
@@ -48,7 +48,6 @@ import (
 
 var cfg *rest.Config
 var k8sClient client.Client
-var k8sClient2 client.Client
 var testEnv *envtest.Environment
 var k8sManager manager.Manager
 
@@ -119,11 +118,6 @@ var _ = BeforeSuite(func(done Done) {
 
 	k8sClient = k8sManager.GetClient()
 	Expect(k8sClient).ToNot(BeNil())
-
-	// FIXME: In some cases previous `k8sClient` seems to be not working
-	k8sClient2, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).ToNot(HaveOccurred())
-	Expect(k8sClient2).ToNot(BeNil())
 
 	close(done)
 }, 60)


### PR DESCRIPTION
- Update ServiceBinding resource's .status.binding.name with the secret
  name that is used binding
- Support ServiceBinding resource's .spec.name to override .metadata.name
  for directory name
- Support ServiceBinding resource's .spec.type to override value from the
  ProvisionedService secret
- Support ServiceBinding resource's .spec.provider to override value from
  the ProvisionedService secret
- Always create a new secret for binding.

Signed-off-by: Baiju Muthukadan <baiju.m.mail@gmail.com>

<!--

Welcome to KubePreset!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
